### PR TITLE
feat(server) filter inline server env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "connected-react-router": "^6.5.2",
     "cookie": "^0.4.0",
     "cross-fetch": "^3.0.4",
+    "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "graphql": "^14.5.5",
     "graphql-tag": "^2.10.1",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,5 +1,7 @@
 import http from 'http'
 
+require('dotenv').config()
+
 let app = require('./server').default
 
 const server = http.createServer(app)

--- a/webpack/blocks/filterEnv.js
+++ b/webpack/blocks/filterEnv.js
@@ -6,9 +6,9 @@ const pickBy = require('lodash/pickBy')
  * @param {Function} filter
  */
 module.exports = (filter) => ({webpack}) => (config) => ({
+  ...config,
   plugins: config.plugins.map((plugin) => {
     if (plugin.constructor.name !== 'DefinePlugin') return plugin
     return new webpack.DefinePlugin(pickBy(plugin.definitions, filter))
-  }),
-  ...config
+  })
 })

--- a/webpack/blocks/filterEnv.js
+++ b/webpack/blocks/filterEnv.js
@@ -1,0 +1,14 @@
+const pickBy = require('lodash/pickBy')
+
+/**
+ * Filters variables from Webpack's DefinePlugin.
+ *
+ * @param {Function} filter
+ */
+module.exports = (filter) => ({webpack}) => (config) => ({
+  plugins: config.plugins.map((plugin) => {
+    if (plugin.constructor.name !== 'DefinePlugin') return plugin
+    return new webpack.DefinePlugin(pickBy(plugin.definitions, filter))
+  }),
+  ...config
+})

--- a/webpack/server.config.js
+++ b/webpack/server.config.js
@@ -1,10 +1,13 @@
+const filterEnv = require('./blocks/filterEnv')
+const merge = require('./blocks/merge')
+const {createConfig, optimization} = require('webpack-blocks')
+
 /**
  * Razzle plugin to modify the server bundle's webpack config
  */
-module.exports = (config, env) => ({
-  ...config,
-  externals: env.dev ? config.externals : undefined,
-  optimization: {
-    minimize: false
-  }
-})
+module.exports = (config, env) =>
+  createConfig([
+    merge({...config, externals: env.dev ? config.externals : undefined}),
+    optimization({minimize: false}),
+    filterEnv((_value, key) => /^process\.env\.RAZZLE_/.test(key))
+  ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -5063,7 +5063,7 @@ dotenv@^6.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
 
-dotenv@^8.0.0:
+dotenv@^8.0.0, dotenv@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.1.0.tgz#d811e178652bfb8a1e593c6dd704ec7e90d85ea2"
   integrity sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==


### PR DESCRIPTION
Reads `PORT` from runtime env vars, instead of inlining in the production build.